### PR TITLE
mount yii2-redactor module if the blog module enabled

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -43,17 +43,21 @@ class Bootstrap implements BootstrapInterface
                 ]
             ];
         }
-        // Add redactor module if not exist (in my case - only in backend)
-        $redactorModule = $this->getModule()->redactorModule;
-        if ($this->getModule()->getIsBackend() && !$app->hasModule($redactorModule)) {
-            $app->setModule($redactorModule, [
-                'class' => 'yii\redactor\RedactorModule',
-                'imageUploadRoute' => ['/blog/upload/image'],
-                'uploadDir' => $this->getModule()->imgFilePath . '/upload/',
-                'uploadUrl' => $this->getModule()->getImgFullPathUrl() . '/upload',
-                'imageAllowExtensions' => ['jpg', 'png', 'gif', 'svg']
-            ]);
+
+        // Add redactor module if not exist (in my case - only in backend) and if the blog module enabled
+        if ($this->getModule()) {
+            $redactorModule = $this->getModule()->redactorModule;
+            if ($this->getModule()->getIsBackend() && !$app->hasModule($redactorModule)) {
+                $app->setModule($redactorModule, [
+                    'class' => 'yii\redactor\RedactorModule',
+                    'imageUploadRoute' => ['/blog/upload/image'],
+                    'uploadDir' => $this->getModule()->imgFilePath . '/upload/',
+                    'uploadUrl' => $this->getModule()->getImgFullPathUrl() . '/upload',
+                    'imageAllowExtensions' => ['jpg', 'png', 'gif', 'svg']
+                ]);
+            }
         }
+
 
         \Yii::setAlias('@akiraz2', \Yii::getAlias('@vendor') . '/akiraz2');
     }


### PR DESCRIPTION
There is a situation when you have more than one project based on the one code base located in different branches. If in each branch you have a different `composer.json`, switching between branches causes a development problem, when you need to run on each switch the `composer install` command. The solution is to have the one identical `composer.json` for each project. In the case of `yii2-blog`, I would the blog was actually enabled in one of the projects and just be listed in another, only for identicality of `composer.json`, so I wouldn't actually have need to enable the blog module just for fixing exception in the code fixed in the PR. 